### PR TITLE
buff nearest_thread, nerf random_thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ The addressing mode of an operand is prefixed to the value, for example `YEET #1
 Syscall numbers:  
 ```
 TRANSFER_OWNERSHIP      = 1 # transfer ownership of the current thread to the player ID specified by DX, up to a maximum of 1.5x the max thread count
-LOCATE_NEAREST_THREAD   = 2 # return the location of the nearest thread of a different owner in DX to a maximum distance of 80 bytes  
-LOCATE_RANDOM_THREAD    = 3 # return the location of a random active thread in DX 
+LOCATE_NEAREST_THREAD   = 2 # return the location of the nearest thread of a different owner in DX to a maximum distance of 256 bytes  
+LOCATE_RANDOM_THREAD    = 3 # return the location of a random active thread in DX to a maximum distance of 1024 bytes
 RANDOM_INT              = 4 # returns a random value in DX
 ```
 Additionally, the assembler will allow for inline bytes, for example:  

--- a/corewar/mars.py
+++ b/corewar/mars.py
@@ -351,10 +351,10 @@ class MARS(object):
                 thread.dx = ERROR_CODE
             
         elif num == LOCATE_NEAREST_THREAD:
-            closest_distance = self.core.size
-            max_distance = 50
-            closest_pc = None
             all_threads = self.thread_pool + self.next_tick_pool
+            closest_distance = self.core.size
+            max_distance = 256
+            closest_pc = None
             for t in all_threads:
                 curr_distance = max(t.pc, thread.pc) - min(t.pc, thread.pc)
                 if curr_distance < closest_distance and curr_distance <= max_distance and t.owner != thread.owner:
@@ -368,7 +368,9 @@ class MARS(object):
         elif num == LOCATE_RANDOM_THREAD:
             all_threads = self.thread_pool + self.next_tick_pool
             all_threads.append(thread)
-            thread.dx = choice(all_threads).pc
+            max_distance = 1024
+            in_range = [t for t in all_threads if max(t.pc, thread.pc) - min(t.pc, thread.pc) <= max_distance]
+            thread.dx = choice(in_range).pc
             
         elif num == RANDOM_INT:
             thread.dx = randint(0, WORD_MAX)

--- a/tests/run_match.py
+++ b/tests/run_match.py
@@ -218,7 +218,7 @@ class InstructionTests(unittest.TestCase):
         runtime.thread_pool = []
         runtime.next_tick_pool = []
         runtime.spawn_new_thread(Thread(0, LOCATE_NEAREST_THREAD, 0, 0))
-        runtime.spawn_new_thread(Thread(51, LOCATE_NEAREST_THREAD, 0, 1))
+        runtime.spawn_new_thread(Thread(257, LOCATE_NEAREST_THREAD, 0, 1))
         runtime.step()
         self.assertEqual(runtime.next_tick_pool[-1].pc, 4)
         self.assertEqual(runtime.next_tick_pool[-1].dx_bytes, b"teey")


### PR DESCRIPTION
- nearest_thread syscall has a max range of 256 now
- random_thread syscall has a max range of 1024 now